### PR TITLE
Fixing wrong lint, run and test commands

### DIFF
--- a/src/universalinit/templates/angular/config.yml
+++ b/src/universalinit/templates/angular/config.yml
@@ -1,5 +1,5 @@
 build_cmd:
-  command: "npm install && ng build"
+  command: "npm install && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -12,11 +12,11 @@ init_files: []
 init_minimal: "Minimal Angular application initialized"
 
 run_tool:
-  command: "ng serve"
+  command: "npm start"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "ng test --watch=false --browsers=ChromeHeadless"
+  command: "npm run test"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,11 +25,9 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx ng lint
-    LINT_EXIT_CODE=$?
-    npx ng build
-    BUILD_EXIT_CODE=$?
-    if [ $LINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    npm run build
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/astro/config.yml
+++ b/src/universalinit/templates/astro/config.yml
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,11 +25,9 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
-    ESLINT_EXIT_CODE=$?
     npm run build
-    BUILD_EXIT_CODE=$?
-    if [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/nativescript/config.yml
+++ b/src/universalinit/templates/nativescript/config.yml
@@ -1,5 +1,5 @@
 build_cmd:
-  command: "npm install && ns build"
+  command: "npm install && ns build" # TODO: FIX
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -12,22 +12,22 @@ init_files: []
 init_minimal: "Minimal NativeScript application initialized"
 
 run_tool:
-  command: "ns run"
+  command: "ns run" # TODO: FIX
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "ns test"
+  command: "ns test" # TODO: FIX
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
 
-linter:
+linter: # TODO: FIX
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
     ns lint
 
-post_processing:
+post_processing: # TODO: FIX
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}

--- a/src/universalinit/templates/nextjs/config.yml
+++ b/src/universalinit/templates/nextjs/config.yml
@@ -1,5 +1,5 @@
 build_cmd:
-  command: "npm install && npm run lint && npm run test"
+  command: "npm install && npm run lint && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm run test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?

--- a/src/universalinit/templates/nuxt/config.yml
+++ b/src/universalinit/templates/nuxt/config.yml
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm run test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,11 +25,9 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
-    ESLINT_EXIT_CODE=$?
     npm run build
-    BUILD_EXIT_CODE=$?
-    if [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/qwik/config.yml
+++ b/src/universalinit/templates/qwik/config.yml
@@ -12,11 +12,11 @@ init_files: []
 init_minimal: "Minimal Qwik application initialized"
 
 run_tool:
-  command: "npm start"
+  command: "npm run dev"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?

--- a/src/universalinit/templates/react/config.yml
+++ b/src/universalinit/templates/react/config.yml
@@ -16,22 +16,18 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm test"
+  command: "npm run test"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
-
-
 
 linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
-    ESLINT_EXIT_CODE=$?
     npm run build
-    BUILD_EXIT_CODE=$?
-    if [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/remix/config.yml
+++ b/src/universalinit/templates/remix/config.yml
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?

--- a/src/universalinit/templates/remotion/config.yml
+++ b/src/universalinit/templates/remotion/config.yml
@@ -12,11 +12,11 @@ init_files: []
 init_minimal: "Minimal Remotion video project initialized"
 
 run_tool:
-  command: "npm run start"
+  command: "npm run dev"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm run test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?

--- a/src/universalinit/templates/slidev/config.yml
+++ b/src/universalinit/templates/slidev/config.yml
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm run build"  # Using build as validation since Slidev doesn't have dedicated tests
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,11 +25,9 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx prettier --write "**/*.{js,ts,md,vue}"
-    PRETTIER_EXIT_CODE=$?
     npm run build
-    BUILD_EXIT_CODE=$?
-    if [ $PRETTIER_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/svelte/config.yml
+++ b/src/universalinit/templates/svelte/config.yml
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?

--- a/src/universalinit/templates/vite/config.yml
+++ b/src/universalinit/templates/vite/config.yml
@@ -16,7 +16,7 @@ run_tool:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 test_tool:
-  command: "npm run test"
+  command: "npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_style: ""
@@ -25,11 +25,9 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
-    ESLINT_EXIT_CODE=$?
     npm run build
-    BUILD_EXIT_CODE=$?
-    if [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
        exit 1
     fi
 

--- a/src/universalinit/templates/vue/config.yml
+++ b/src/universalinit/templates/vue/config.yml
@@ -25,7 +25,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npx eslint --fix "$@"
+    npm run lint
     ESLINT_EXIT_CODE=$?
     npm run build
     BUILD_EXIT_CODE=$?


### PR DESCRIPTION
# Description

Updated the commands in the `config.yml` files of the templates to fix wrong commands that were generating unexpected outputs, specially those with `npx`.