### PR TITLE
Fixed remotion template

### DIFF
--- a/src/universalinit/templates/remotion/package.json
+++ b/src/universalinit/templates/remotion/package.json
@@ -6,17 +6,15 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@remotion/cli": "4.0.273",
-    "@remotion/zod-types": "4.0.273",
+    "@remotion/cli": "4.0.286",
+    "@remotion/zod-types": "4.0.286",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "remotion": "4.0.273",
-    "zod": "3.22.3",
-    "@remotion/tailwind-v4": "4.0.273",
-    "tailwindcss": "4.0.0"
+    "remotion": "4.0.286",
+    "zod": "3.22.3"
   },
   "devDependencies": {
-    "@remotion/eslint-config-flat": "4.0.273",
+    "@remotion/eslint-config-flat": "4.0.286",
     "@types/react": "19.0.0",
     "@types/web": "0.0.166",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
@@ -30,8 +28,5 @@
     "build": "remotion bundle",
     "upgrade": "remotion upgrade",
     "lint": "eslint src && tsc"
-  },
-  "sideEffects": [
-    "*.css"
-  ]
+  }
 }

--- a/src/universalinit/templates/remotion/postcss.config.mjs
+++ b/src/universalinit/templates/remotion/postcss.config.mjs
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};

--- a/src/universalinit/templates/remotion/remotion.config.ts
+++ b/src/universalinit/templates/remotion/remotion.config.ts
@@ -4,8 +4,6 @@
 // Note: When using the Node.JS APIs, the config file doesn't apply. Instead, pass options directly to the APIs
 
 import { Config } from "@remotion/cli/config";
-import { enableTailwind } from '@remotion/tailwind-v4';
 
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
-Config.overrideWebpackConfig(enableTailwind);

--- a/src/universalinit/templates/remotion/src/Root.tsx
+++ b/src/universalinit/templates/remotion/src/Root.tsx
@@ -1,4 +1,3 @@
-import "./index.css";
 import { Composition } from "remotion";
 import { HelloWorld, myCompSchema } from "./HelloWorld";
 import { Logo, myCompSchema2 } from "./HelloWorld/Logo";

--- a/src/universalinit/templates/remotion/src/index.css
+++ b/src/universalinit/templates/remotion/src/index.css
@@ -1,1 +1,0 @@
-@import "tailwindcss";


### PR DESCRIPTION
# Description

The remotion template wasn't running out of the box due to an incompatibility issue with tailwind css.
I've created a new template that doesn't use the tailwind css.