### PR TITLE
create and enter venv before pip install

### DIFF
--- a/src/universalinit/templates/fastapi/config.yml
+++ b/src/universalinit/templates/fastapi/config.yml
@@ -1,5 +1,7 @@
 build_cmd:
-  command: "pip install -r requirements.txt" 
+  command: "python3 -m venv venv && \
+            source venv/bin/activate && \
+            pip install -r requirements.txt" 
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -35,4 +37,6 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
+    python3 -m venv venv
+    source venv/bin/activate
     pip install -r requirements.txt


### PR DESCRIPTION
# Description
Fixed FastAPI config.yaml to create/enter the venv before running pip install. 
Otherwise there is an error for trying to install packages system-wide.