### PR TITLE
Fix/inconsistencies in background running frameworks batch 1

### DIFF
--- a/src/universalinit/templates/angular/config.yml
+++ b/src/universalinit/templates/angular/config.yml
@@ -36,5 +36,6 @@ linter:
 post_processing:
   script: |
     #!/bin/bash
+    export NG_CLI_ANALYTICS=false
     cd {KAVIA_PROJECT_DIRECTORY}
     npm install

--- a/src/universalinit/templates/angular/package.json
+++ b/src/universalinit/templates/angular/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0  --no-hmr --disable-host-check",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/src/universalinit/templates/astro/package.json
+++ b/src/universalinit/templates/astro/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "astro dev --host 0.0.0.0",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/src/universalinit/templates/nextjs/package.json
+++ b/src/universalinit/templates/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000 -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/universalinit/templates/qwik/package.json
+++ b/src/universalinit/templates/qwik/package.json
@@ -13,7 +13,7 @@
     "build.preview": "vite build --ssr src/entry.preview.tsx",
     "build.types": "tsc --incremental --noEmit",
     "deploy": "echo 'Run \"npm run qwik add\" to install a server adapter'",
-    "dev": "vite --mode ssr",
+    "dev": "vite --mode ssr --host 0.0.0.0",
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",

--- a/src/universalinit/templates/remix/package.json
+++ b/src/universalinit/templates/remix/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build",
-    "dev": "remix vite:dev",
+    "dev": "remix vite:dev --host 0.0.0.0",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve ./build/server/index.js",
     "typecheck": "tsc"


### PR DESCRIPTION
# Description
We had several inconsistencies when trying to access the projects running inside the docker from the outside

# Changes
Adjusts the following frameworks to be able to run without interaction and be exposed to outside the docker network:
- Angular
- Astro
- Qwik
- Remix
- Nextjs

Nuxt and React were already working fine from the universalinit perspective.