### PR TITLE
Added allowed hosts, to vite, vue and svelte

### DIFF
--- a/src/universalinit/templates/svelte/vite.config.ts
+++ b/src/universalinit/templates/svelte/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [sveltekit()],
     server: {
         host: '0.0.0.0',
+        allowedHosts: ['*.kavia.ai', '*'],
         port: 3000,
         strictPort: true,
         cors: true,

--- a/src/universalinit/templates/vite/vite.config.js
+++ b/src/universalinit/templates/vite/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
     server: {
         host: '0.0.0.0',
+        allowedHosts: ['*.kavia.ai', '*'],
         port: 3000,
         strictPort: true,
         cors: true,

--- a/src/universalinit/templates/vue/vite.config.ts
+++ b/src/universalinit/templates/vue/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
+    allowedHosts: ['*.kavia.ai', '*'],
     port: 3000,
     strictPort: true,
     cors: true,

--- a/test/test_android_template.py
+++ b/test/test_android_template.py
@@ -18,7 +18,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_angular_template.py
+++ b/test/test_angular_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_django_template.py
+++ b/test/test_django_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_express_template.py
+++ b/test/test_express_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_fastapi_template.py
+++ b/test/test_fastapi_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_flask_template.py
+++ b/test/test_flask_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,7 +15,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_kotlin_template.py
+++ b/test/test_kotlin_template.py
@@ -202,6 +202,7 @@ def test_post_processing_execution(template_dir, project_config, temp_dir):
 
     success = initializer.initialize_project(project_config)
     assert success
+    assert initializer.wait_for_post_process_completed()
     
     assert project_config.output_path.exists()
     assert (project_config.output_path / "src").exists()

--- a/test/test_kotlin_template.py
+++ b/test/test_kotlin_template.py
@@ -16,7 +16,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture
@@ -203,7 +203,7 @@ def test_post_processing_execution(template_dir, project_config, temp_dir):
     success = initializer.initialize_project(project_config)
     assert success
     assert initializer.wait_for_post_process_completed()
-    
+
     assert project_config.output_path.exists()
     assert (project_config.output_path / "src").exists()
 

--- a/test/test_nextjs_template.py
+++ b/test/test_nextjs_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_nuxt_template.py
+++ b/test/test_nuxt_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_qwik_template.py
+++ b/test/test_qwik_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_remix_template.py
+++ b/test/test_remix_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_remotion_template.py
+++ b/test/test_remotion_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_slidev_template.py
+++ b/test/test_slidev_template.py
@@ -222,7 +222,7 @@ def test_slidev_registration():
         description="Test Slidev",
         author="Test Author", 
         project_type=ProjectType.SLIDEV,
-        output_path=Path("output"),
+        output_path=Path("/tmp/output"),
         parameters={}
     )
     
@@ -239,7 +239,7 @@ def test_slidev_validation():
         description="Test Slidev Application",
         author="Test Author",
         project_type=ProjectType.SLIDEV,
-        output_path=Path("output"),
+        output_path=Path("/tmp/output"),
         parameters={}  # Empty parameters should be valid for Slidev
     )
     

--- a/test/test_slidev_template.py
+++ b/test/test_slidev_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_svelte_template.py
+++ b/test/test_svelte_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_typescript_template.py
+++ b/test/test_typescript_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_vite_template.py
+++ b/test/test_vite_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/test/test_vue_template.py
+++ b/test/test_vue_template.py
@@ -14,7 +14,7 @@ def temp_dir():
     """Create a temporary directory for test outputs."""
     temp_path = Path(tempfile.mkdtemp())
     yield temp_path
-    shutil.rmtree(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description
The following issue is happening in production for Vue, Vite and Svelte:
```
Blocked request. This host ("vscode-internal-5801-beta.beta.cloud.kavia.ai") is not allowed.
To allow this host, add "vscode-internal-5801-beta.beta cloud kavia.ai" to
"server.allowedHosts' in vite.config.js.
```

# Changes
- Added `allowedHosts` to `vite.config.js`.