### PR TITLE
fix: enter venv before running lint

### DIFF
--- a/src/universalinit/templates/fastapi/config.yml
+++ b/src/universalinit/templates/fastapi/config.yml
@@ -29,6 +29,7 @@ linter:
   script_content: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
+    source venv/bin/activate
     flake8 .
     LINT_EXIT_CODE=$?
     if [ $LINT_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
# Description
Bugfix: enter venv before running flake8 in linter command.