### PR TITLE
Fix Astro version and enable all hosts

### DIFF
--- a/src/universalinit/templates/astro/astro.config.mjs
+++ b/src/universalinit/templates/astro/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
     server: {
         host: '0.0.0.0',
-        allowedHosts: true,
+        allowedHosts: ['*'],
         port: 3000,
         headers: {
             'Access-Control-Allow-Origin': '*'

--- a/src/universalinit/templates/astro/package.json
+++ b/src/universalinit/templates/astro/package.json
@@ -10,15 +10,15 @@
     "lint": "npx eslint"
   },
   "dependencies": {
-    "astro": "^5.4.2"
+    "astro": "5.4.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.24.0",
-    "@typescript-eslint/eslint-plugin": "^8.29.0",
-    "@typescript-eslint/parser": "^8.29.0",
-    "eslint": "^9.24.0",
-    "globals": "^16.0.0",
-    "typescript": "^5.8.2",
-    "typescript-eslint": "^8.29.0"
+    "@eslint/js": "9.24.0",
+    "@typescript-eslint/eslint-plugin": "8.29.0",
+    "@typescript-eslint/parser": "8.29.0",
+    "eslint": "9.24.0",
+    "globals": "16.0.0",
+    "typescript": "5.8.2",
+    "typescript-eslint": "8.29.0"
   }
 }


### PR DESCRIPTION
We fix Astro version to be able to run with current node version. 
This version requires ['*'] instead of true to enable all hosts.