### PR TITLE
Fixing AllowedHosts for all frameworks

### DIFF
--- a/src/universalinit/templates/angular/angular.json
+++ b/src/universalinit/templates/angular/angular.json
@@ -72,7 +72,9 @@
           },
           "defaultConfiguration": "development",
           "options": {
-            "port": 3000
+            "port": 3000,
+            "host": "0.0.0.0",
+            "disableHostCheck": true
           }
         },
         "extract-i18n": {

--- a/src/universalinit/templates/astro/astro.config.mjs
+++ b/src/universalinit/templates/astro/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
     server: {
         host: '0.0.0.0',
-        allowedHosts: ['*'],
+        allowedHosts: ['.kavia.ai'],
         port: 3000,
         headers: {
             'Access-Control-Allow-Origin': '*'

--- a/src/universalinit/templates/django/config/settings.py
+++ b/src/universalinit/templates/django/config/settings.py
@@ -25,7 +25,11 @@ SECRET_KEY = 'django-insecure-0ku_as45vs5isd^px=t#m8g#^*x7f=w#gw-xb^t@^-pom)r^t6
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    '.kavia.ai',
+    'localhost',
+    '127.0.0.1',
+]
 
 
 # Application definition

--- a/src/universalinit/templates/express/src/server.js
+++ b/src/universalinit/templates/express/src/server.js
@@ -1,7 +1,7 @@
 const app = require('./app');
 
 const PORT = process.env.PORT || 3000;
-const HOST = process.env.HOST || 'localhost';
+const HOST = process.env.HOST || '0.0.0.0';
 
 const server = app.listen(PORT, HOST, () => {
   console.log(`Server running at http://${HOST}:${PORT}`);

--- a/src/universalinit/templates/lightningjs/vite.config.js
+++ b/src/universalinit/templates/lightningjs/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
       mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],
     },
     server: {
+      host: '0.0.0.0',
+      allowedHosts: ['.kavia.ai'],
+      port: 3000,
       headers: {
         'Cross-Origin-Opener-Policy': 'same-origin',
         'Cross-Origin-Embedder-Policy': 'require-corp',

--- a/src/universalinit/templates/nuxt/nuxt.config.ts
+++ b/src/universalinit/templates/nuxt/nuxt.config.ts
@@ -13,7 +13,9 @@ export default defineNuxtConfig({
   },
   vite: {
     server: {
+      host: '0.0.0.0',
       allowedHosts: true,
+      port: 3000,
     },
   },
 });

--- a/src/universalinit/templates/qwik/vite.config.ts
+++ b/src/universalinit/templates/qwik/vite.config.ts
@@ -52,6 +52,8 @@ export default defineConfig(({ command, mode }): UserConfig => {
         "Cache-Control": "public, max-age=0",
       },
       port: 3000,
+      host: '0.0.0.0',
+      allowedHosts: ['.kavia.ai'],
     },
     preview: {
       headers: {

--- a/src/universalinit/templates/remotion/package.json
+++ b/src/universalinit/templates/remotion/package.json
@@ -24,7 +24,7 @@
     "typescript": "5.5.4"
   },
   "scripts": {
-    "dev": "remotion studio",
+    "dev": "remotion studio  --host 0.0.0.0",
     "build": "remotion bundle",
     "upgrade": "remotion upgrade",
     "lint": "eslint src && tsc"

--- a/src/universalinit/templates/slidev/vite.config.ts
+++ b/src/universalinit/templates/slidev/vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   server: {
       host: '0.0.0.0',
       port: 3000,
-      allowedHosts: true,
+      allowedHosts: ['.kavia.ai'],
       headers: {
           'Access-Control-Allow-Origin': '*'
       },

--- a/src/universalinit/templates/svelte/vite.config.ts
+++ b/src/universalinit/templates/svelte/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [sveltekit()],
   server: {
     host: "0.0.0.0",
-    allowedHosts: true,
+    allowedHosts: ['.kavia.ai'],
     port: 3000,
     strictPort: true,
     cors: true,

--- a/src/universalinit/templates/typescript/vite.config.ts
+++ b/src/universalinit/templates/typescript/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   server: {
     host: '0.0.0.0',
-    allowedHosts: true,
+    allowedHosts: ['.kavia.ai'],
     port: 3000,
     strictPort: true,
     cors: true,

--- a/src/universalinit/templates/vite/vite.config.js
+++ b/src/universalinit/templates/vite/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
     server: {
         host: '0.0.0.0',
-        allowedHosts: true,
+        allowedHosts: ['.kavia.ai'],
         port: 3000,
         strictPort: true,
         cors: true,

--- a/src/universalinit/templates/vue/vite.config.ts
+++ b/src/universalinit/templates/vue/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
-    allowedHosts: true,
+    allowedHosts: ['.kavia.ai'],
     port: 3000,
     strictPort: true,
     cors: true,


### PR DESCRIPTION
# Description
We're still having issues with the `allowedHosts` configuration.

# Changes
- Adjusted allowedHosts configuration in every framework
- Changed '*' to '.kavia.ai' in frameworks that seems not to be working properly