### PR TITLE
add nodemon.json to prevent express from unnecessarily reloading

### DIFF
--- a/src/universalinit/templates/express/nodemon.json
+++ b/src/universalinit/templates/express/nodemon.json
@@ -1,0 +1,11 @@
+{
+  "ignore": [
+    "node_modules/*",
+    "post_process_status.lock",
+    "*.log", "**/*.log"
+  ],
+  "watch": [
+    "src"
+  ],
+  "ext": "js,json"
+}


### PR DESCRIPTION
Add `nodemon.json` file to ignore some files triggering reload of the server unnecessarily.