### PR TITLE
Fixed typo

### DIFF
--- a/src/universalinit/cli.py
+++ b/src/universalinit/cli.py
@@ -50,8 +50,8 @@ def template_init_info_to_dict(init_info: TemplateInitInfo, project_path: Path) 
 
     return {
         "configure_environment":{
-            "command": init_info.configure_enviroment.command,
-            "working_directory": init_info.configure_enviroment.working_directory,
+            "command": init_info.configure_environment.command,
+            "working_directory": init_info.configure_environment.working_directory,
         },
         "build_cmd": {
             "command": init_info.build_cmd.command,

--- a/src/universalinit/cli.py
+++ b/src/universalinit/cli.py
@@ -50,8 +50,8 @@ def template_init_info_to_dict(init_info: TemplateInitInfo, project_path: Path) 
 
     return {
         "configure_environment":{
-            "command": init_info.configure_environment.command,
-            "working_directory": init_info.configure_environment.working_directory,
+            "command": init_info.configure_environment.command if init_info.configure_environment else '',
+            "working_directory": init_info.configure_environment.working_directory if init_info.configure_environment else '',
         },
         "build_cmd": {
             "command": init_info.build_cmd.command,

--- a/src/universalinit/templateconfig.py
+++ b/src/universalinit/templateconfig.py
@@ -153,7 +153,6 @@ class OpenapiGenerationTool:
 @dataclass
 class TemplateInitInfo:
     """Complete template initialization information."""
-    configure_environment: Optional[ConfigureEnvironment] = None
     build_cmd: BuildCommand
     install_dependencies: InstallDependenciesCommand
     env_config: EnvironmentConfig
@@ -167,6 +166,7 @@ class TemplateInitInfo:
     post_processing: ProcessingScript
     entry_point_url: Optional[str] = None
     openapi_generation: Optional[OpenapiGenerationTool] = None
+    configure_environment: Optional[ConfigureEnvironment] = None
 
 class TemplateConfigProvider:
     """Provides template initialization configuration."""
@@ -190,7 +190,7 @@ class TemplateConfigProvider:
             configure_environment=ConfigureEnvironment(
                 command=config_data.get('configure_environment', {}).get('command', ''),
                 working_directory=config_data.get('configure_environment', {}).get('working_directory', '')
-            ),
+            ) if 'configure_environment' in config_data else None,
             build_cmd=BuildCommand(
                 command=config_data['build_cmd']['command'],
                 working_directory=config_data['build_cmd']['working_directory']

--- a/src/universalinit/templateconfig.py
+++ b/src/universalinit/templateconfig.py
@@ -153,7 +153,7 @@ class OpenapiGenerationTool:
 @dataclass
 class TemplateInitInfo:
     """Complete template initialization information."""
-    configure_enviroment: ConfigureEnvironment
+    configure_environment: Optional[ConfigureEnvironment] = None
     build_cmd: BuildCommand
     install_dependencies: InstallDependenciesCommand
     env_config: EnvironmentConfig
@@ -187,9 +187,9 @@ class TemplateConfigProvider:
             config_data = yaml.safe_load(data)
 
         return TemplateInitInfo(
-            configure_enviroment=ConfigureEnvironment(
-                command=config_data['configure_environment']['command'],
-                working_directory=config_data['configure_environment']['working_directory']
+            configure_environment=ConfigureEnvironment(
+                command=config_data.get('configure_environment', {}).get('command', ''),
+                working_directory=config_data.get('configure_environment', {}).get('working_directory', '')
             ),
             build_cmd=BuildCommand(
                 command=config_data['build_cmd']['command'],

--- a/test/test_android_template.py
+++ b/test/test_android_template.py
@@ -266,7 +266,7 @@ def test_android_init_info(template_dir, project_config):
     assert init_info.test_tool.command == './gradlew test'
     assert init_info.init_style == 'android'
     assert init_info.openapi_generation.command == ''
-    assert init_info.configure_enviroment.command == './gradlew assembleDebug'
+    assert init_info.configure_environment.command == './gradlew assembleDebug'
 
 
 def test_android_with_missing_template_config(temp_dir, project_config):

--- a/test/test_angular_template.py
+++ b/test/test_angular_template.py
@@ -98,7 +98,7 @@ def test_angular_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_astro_template.py
+++ b/test/test_astro_template.py
@@ -108,7 +108,7 @@ def test_astro_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_django_template.py
+++ b/test/test_django_template.py
@@ -92,7 +92,7 @@ def test_django_init_info(template_dir, project_config):
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
     assert init_info.openapi_generation.command == 'python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python manage.py migrate && python manage.py generate_openapi'
-    assert init_info.configure_enviroment.command == 'python3 -m venv venv && \
+    assert init_info.configure_environment.command == 'python3 -m venv venv && \
                 source venv/bin/activate && \
                 pip install -r requirements.txt && \
                 python manage.py makemigrations && \

--- a/test/test_express_template.py
+++ b/test/test_express_template.py
@@ -104,7 +104,7 @@ def test_express_init_info(template_dir, project_config):
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
     assert init_info.openapi_generation.command == 'npm install && node generate_openapi.js'
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_fastapi_template.py
+++ b/test/test_fastapi_template.py
@@ -129,7 +129,7 @@ def test_fastapi_init_info(template_dir, project_config):
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
     assert init_info.openapi_generation.command == 'python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python src/api/generate_openapi.py'
-    assert init_info.configure_enviroment.command == 'python3 -m venv venv && \
+    assert init_info.configure_environment.command == 'python3 -m venv venv && \
                 source venv/bin/activate && \
                 pip install -r requirements.txt'
 

--- a/test/test_flask_template.py
+++ b/test/test_flask_template.py
@@ -135,7 +135,7 @@ def test_flask_init_info(template_dir, project_config):
             source venv/bin/activate && \
             pip install -r requirements.txt && \
             python src/api/generate_openapi.py"
-    assert init_info.configure_enviroment.command == 'python3 -m venv venv && \
+    assert init_info.configure_environment.command == 'python3 -m venv venv && \
                 source venv/bin/activate && \
                 pip install -r requirements.txt'
 

--- a/test/test_flutter_template.py
+++ b/test/test_flutter_template.py
@@ -370,7 +370,7 @@ def test_flutter_init_info(template_dir, project_config):
     assert init_info.env_config.dart_version == '3.6.1'
     assert init_info.run_tool.command == 'flutter run'
     assert init_info.test_tool.command == 'flutter test'
-    assert init_info.configure_enviroment.command == 'flutter build apk --release --target-platform android-x64'
+    assert init_info.configure_environment.command == 'flutter build apk --release --target-platform android-x64'
 
 
 def test_flutter_with_missing_template_config(temp_dir, project_config):

--- a/test/test_kotlin_template.py
+++ b/test/test_kotlin_template.py
@@ -270,7 +270,7 @@ def test_kotlin_init_info(template_dir, project_config):
     assert init_info.run_tool.command == './gradlew run'
     assert init_info.test_tool.command == './gradlew test'
     assert init_info.init_style == 'kotlin'
-    assert init_info.configure_enviroment.command == './gradlew assembleDebug'
+    assert init_info.configure_environment.command == './gradlew assembleDebug'
 
 
 def test_kotlin_with_missing_template_config(temp_dir, project_config):

--- a/test/test_lightningjs_template.py
+++ b/test/test_lightningjs_template.py
@@ -102,7 +102,7 @@ def test_lightningjs_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_mongodb_template.py
+++ b/test/test_mongodb_template.py
@@ -153,7 +153,7 @@ def test_mongodb_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
+    assert init_info.configure_environment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_mysql_template.py
+++ b/test/test_mysql_template.py
@@ -152,7 +152,7 @@ def test_mysql_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
+    assert init_info.configure_environment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nativescript_template.py
+++ b/test/test_nativescript_template.py
@@ -169,7 +169,7 @@ def test_nativescript_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nextjs_template.py
+++ b/test/test_nextjs_template.py
@@ -106,7 +106,7 @@ def test_nextjs_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nuxt_template.py
+++ b/test/test_nuxt_template.py
@@ -98,7 +98,7 @@ def test_nuxt_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_postgresql_template.py
+++ b/test/test_postgresql_template.py
@@ -201,7 +201,7 @@ def test_postgresql_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
+    assert init_info.configure_environment.command == 'chmod +x startup.sh && sudo ./startup.sh &'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_qwik_template.py
+++ b/test/test_qwik_template.py
@@ -113,7 +113,7 @@ def test_qwik_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_remix_template.py
+++ b/test/test_remix_template.py
@@ -104,7 +104,7 @@ def test_remix_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_remotion_template.py
+++ b/test/test_remotion_template.py
@@ -98,7 +98,7 @@ def test_remotion_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_slidev_template.py
+++ b/test/test_slidev_template.py
@@ -111,7 +111,7 @@ def test_slidev_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_sqlite_template.py
+++ b/test/test_sqlite_template.py
@@ -254,7 +254,7 @@ def test_sqlite_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'python init_db.py'
+    assert init_info.configure_environment.command == 'python init_db.py'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_svelte_template.py
+++ b/test/test_svelte_template.py
@@ -101,7 +101,7 @@ def test_svelte_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 def test_project_initialization(template_dir, project_config):
     """Test basic project initialization."""

--- a/test/test_typescript_template.py
+++ b/test/test_typescript_template.py
@@ -99,7 +99,7 @@ def test_typescript_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 

--- a/test/test_vite_template.py
+++ b/test/test_vite_template.py
@@ -102,7 +102,7 @@ def test_vite_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_vue_template.py
+++ b/test/test_vue_template.py
@@ -98,7 +98,7 @@ def test_vue_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_enviroment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install'
 
 
 def test_project_initialization(template_dir, project_config):


### PR DESCRIPTION
# Description
There was a typo in the configure environment command, where it was `configure_enviroment` instead of `configure_environment`.
This is fixed while also making it optional.