### PR TITLE
run generate_openapi as a module in fastapi

### DIFF
--- a/src/universalinit/templates/fastapi/config.yml
+++ b/src/universalinit/templates/fastapi/config.yml
@@ -23,7 +23,7 @@ openapi_generation:
   command: "python3 -m venv venv && \
             source venv/bin/activate && \
             pip install -r requirements.txt && \
-            python src/api/generate_openapi.py"
+            python -m src.api.generate_openapi"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 init_files: []

--- a/src/universalinit/templates/fastapi/src/api/generate_openapi.py
+++ b/src/universalinit/templates/fastapi/src/api/generate_openapi.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from main import app
+from src.api.main import app
 
 # Get the OpenAPI schema
 openapi_schema = app.openapi()


### PR DESCRIPTION
In FastAPI, running generate_openapi.py as a script causes trouble when there are relative imports in the main app. 
Therefore, we run it as a package.
