### PR TITLE
Replacing "npm install" with "npm install --legacy-peer-deps"

### DIFF
--- a/src/universalinit/templates/angular/config.yml
+++ b/src/universalinit/templates/angular/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -46,4 +46,4 @@ post_processing:
     #!/bin/bash
     export NG_CLI_ANALYTICS=false
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/astro/README.md
+++ b/src/universalinit/templates/astro/README.md
@@ -35,7 +35,7 @@ All commands are run from the root of the project, from a terminal:
 
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
+| `npm install --legacy-peer-deps`             | Installs dependencies                            |
 | `npm run dev`             | Starts local dev server at `localhost:4321`      |
 | `npm run build`           | Build your production site to `./dist/`          |
 | `npm run preview`         | Preview your build locally, before deploying     |

--- a/src/universalinit/templates/astro/config.yml
+++ b/src/universalinit/templates/astro/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
   
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/express/config.yml
+++ b/src/universalinit/templates/express/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install" 
+  command: "npm install --legacy-peer-deps" 
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -20,7 +20,7 @@ init_files: []
 init_minimal: "Minimal Express application initialized"
 
 openapi_generation:
-  command: "npm install && node generate_openapi.js"
+  command: "npm install --legacy-peer-deps && node generate_openapi.js"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 run_tool:
@@ -49,5 +49,5 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps
     npm run lint

--- a/src/universalinit/templates/lightningjs/README.md
+++ b/src/universalinit/templates/lightningjs/README.md
@@ -18,7 +18,7 @@ It is highly recommended to install the Blits [VS-code extension](https://market
 Run the following command to install the dependencies of your App:
 
 ```sh
-npm install
+npm install --legacy-peer-deps
 ```
 
 #### Build and run in development mode

--- a/src/universalinit/templates/lightningjs/config.yml
+++ b/src/universalinit/templates/lightningjs/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/lightningjs/docs/getting_started_getting_started.md
+++ b/src/universalinit/templates/lightningjs/docs/getting_started_getting_started.md
@@ -30,7 +30,7 @@ own Lightning 3 App.
 
 ``` {.shiki .shiki-themes .github-light .github-dark .vp-code tabindex="0"}
 cd my_blits_app
-npm install
+npm install --legacy-peer-deps
 ```
 :::
 

--- a/src/universalinit/templates/mongodb/config.yml
+++ b/src/universalinit/templates/mongodb/config.yml
@@ -7,7 +7,7 @@ build_cmd:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "cd db_visualizer && npm install"
+  command: "cd db_visualizer && npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
   
 env:
@@ -43,5 +43,5 @@ post_processing:
     chmod +x startup.sh
     sudo ./startup.sh
     cd db_visualizer
-    npm install
+    npm install --legacy-peer-deps
     echo "MongoDB is starting on port {KAVIA_DB_PORT}..."

--- a/src/universalinit/templates/mysql/config.yml
+++ b/src/universalinit/templates/mysql/config.yml
@@ -7,7 +7,7 @@ build_cmd:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "cd db_visualizer && npm install"
+  command: "cd db_visualizer && npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
   
 env:
@@ -43,5 +43,5 @@ post_processing:
     chmod +x startup.sh
     sudo ./startup.sh
     cd db_visualizer
-    npm install
+    npm install --legacy-peer-deps
     echo "MySQL is starting on port {KAVIA_DB_PORT}..."

--- a/src/universalinit/templates/nativescript/config.yml
+++ b/src/universalinit/templates/nativescript/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && ns build" # TODO: FIX
+  command: "npm install --legacy-peer-deps && ns build" # TODO: FIX
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -53,4 +53,4 @@ post_processing: # TODO: FIX
     fi
     
     # Install dependencies
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/nextjs/config.yml
+++ b/src/universalinit/templates/nextjs/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run lint && npm run build"
+  command: "npm install --legacy-peer-deps && npm run lint && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/nuxt/README.md
+++ b/src/universalinit/templates/nuxt/README.md
@@ -8,10 +8,10 @@ Make sure to install dependencies:
 
 ```bash
 # npm
-npm install
+npm install --legacy-peer-deps
 
 # pnpm
-pnpm install
+pnpm install --legacy-peer-deps
 
 # yarn
 yarn install

--- a/src/universalinit/templates/nuxt/config.yml
+++ b/src/universalinit/templates/nuxt/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/postgresql/config.yml
+++ b/src/universalinit/templates/postgresql/config.yml
@@ -7,7 +7,7 @@ build_cmd:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "cd db_visualizer && npm install"
+  command: "cd db_visualizer && npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
   
 env:
@@ -43,5 +43,5 @@ post_processing:
     chmod +x startup.sh
     sudo ./startup.sh
     cd db_visualizer
-    npm install
+    npm install --legacy-peer-deps
     echo "PostgreSQL is starting on port {KAVIA_DB_PORT}..."

--- a/src/universalinit/templates/qwik/config.yml
+++ b/src/universalinit/templates/qwik/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/react/config.yml
+++ b/src/universalinit/templates/react/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npx tsc --noEmit && npm test -- --ci"
+  command: "npm install --legacy-peer-deps && npx tsc --noEmit && npm test -- --ci"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -43,4 +43,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/remix/config.yml
+++ b/src/universalinit/templates/remix/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/remotion/config.yml
+++ b/src/universalinit/templates/remotion/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/slidev/README.md
+++ b/src/universalinit/templates/slidev/README.md
@@ -2,7 +2,7 @@
 
 To start the slide show:
 
-- `pnpm install`
+- `pnpm install --legacy-peer-deps`
 - `pnpm dev`
 - visit <http://localhost:3030>
 

--- a/src/universalinit/templates/slidev/config.yml
+++ b/src/universalinit/templates/slidev/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/sqlite/config.yml
+++ b/src/universalinit/templates/sqlite/config.yml
@@ -7,7 +7,7 @@ build_cmd:
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies:
-  command: "cd db_visualizer && npm install"
+  command: "cd db_visualizer && npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
   
 env:
@@ -41,5 +41,5 @@ post_processing:
     cd {KAVIA_PROJECT_DIRECTORY}
     python init_db.py
     cd db_visualizer
-    npm install
+    npm install --legacy-peer-deps
     echo "SQLite database is ready at {KAVIA_DB_NAME}"

--- a/src/universalinit/templates/svelte/README.md
+++ b/src/universalinit/templates/svelte/README.md
@@ -16,7 +16,7 @@ npx sv create my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install --legacy-peer-deps` (or `pnpm install --legacy-peer-deps` or `yarn`), start a development server:
 
 ```bash
 npm run dev

--- a/src/universalinit/templates/svelte/config.yml
+++ b/src/universalinit/templates/svelte/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run check && npm run test"
+  command: "npm install --legacy-peer-deps && npm run check && npm run test"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,5 +45,5 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps
     npm run prepare

--- a/src/universalinit/templates/typescript/config.yml
+++ b/src/universalinit/templates/typescript/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/vite/config.yml
+++ b/src/universalinit/templates/vite/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run build"
+  command: "npm install --legacy-peer-deps && npm run build"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/src/universalinit/templates/vue/README.md
+++ b/src/universalinit/templates/vue/README.md
@@ -17,7 +17,7 @@ See [Vite Configuration Reference](https://vite.dev/config/).
 ## Project Setup
 
 ```sh
-npm install
+npm install --legacy-peer-deps
 ```
 
 ### Compile and Hot-Reload for Development

--- a/src/universalinit/templates/vue/config.yml
+++ b/src/universalinit/templates/vue/config.yml
@@ -1,13 +1,13 @@
 configure_environment:
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 build_cmd:
-  command: "npm install && npm run type-check && npm run test:unit -- --run"
+  command: "npm install --legacy-peer-deps && npm run type-check && npm run test:unit -- --run"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 install_dependencies: 
-  command: "npm install"
+  command: "npm install --legacy-peer-deps"
   working_directory: "{KAVIA_PROJECT_DIRECTORY}"
 
 env:
@@ -45,4 +45,4 @@ post_processing:
   script: |
     #!/bin/bash
     cd {KAVIA_PROJECT_DIRECTORY}
-    npm install
+    npm install --legacy-peer-deps

--- a/test/test_angular_template.py
+++ b/test/test_angular_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(angular_path)
         },
         'build_cmd': {
-            'command': 'npm install && ng build',
+            'command': 'npm install --legacy-peer-deps && ng build',
             'working_directory': str(angular_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(angular_path)
         },        
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nng lint'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -98,7 +98,7 @@ def test_angular_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_astro_template.py
+++ b/test/test_astro_template.py
@@ -32,15 +32,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(astro_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(astro_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(astro_path)
         },    
         'env': {
@@ -63,7 +63,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -108,7 +108,7 @@ def test_astro_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_express_template.py
+++ b/test/test_express_template.py
@@ -27,7 +27,7 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(express_path)
         },
         'build_cmd': {
@@ -35,7 +35,7 @@ def template_dir(temp_dir):
             'working_directory': str(express_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(express_path)
         },      
         'env': {
@@ -50,7 +50,7 @@ def template_dir(temp_dir):
             'working_directory': str(express_path)
         },
         "openapi_generation": {
-            "command": "npm install && node generate_openapi.js",
+            "command": "npm install --legacy-peer-deps && node generate_openapi.js",
             "working_directory": str(express_path)
         },
         'test_tool': {
@@ -103,8 +103,8 @@ def test_express_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.openapi_generation.command == 'npm install && node generate_openapi.js'
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.openapi_generation.command == 'npm install --legacy-peer-deps && node generate_openapi.js'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -28,15 +28,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(react_path)
         },
         'build_cmd': {
-            'command': 'npm install && npx tsc --noEmit && npm test -- --ci',
+            'command': 'npm install --legacy-peer-deps && npx tsc --noEmit && npm test -- --ci',
             'working_directory': str(react_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(react_path)
         },
         'env': {
@@ -60,7 +60,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\neslint "$@"'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 

--- a/test/test_lightningjs_template.py
+++ b/test/test_lightningjs_template.py
@@ -27,11 +27,11 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(lightningjs_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(lightningjs_path)
         },
         'install_dependencies': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -102,7 +102,7 @@ def test_lightningjs_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nativescript_template.py
+++ b/test/test_nativescript_template.py
@@ -33,15 +33,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nativescript_path)
         },
         'build_cmd': {
-            'command': 'npm install && ns build',
+            'command': 'npm install --legacy-peer-deps && ns build',
             'working_directory': str(nativescript_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nativescript_path)
         },
         'env': {
@@ -64,7 +64,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nns lint'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -169,7 +169,7 @@ def test_nativescript_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nextjs_template.py
+++ b/test/test_nextjs_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nextjs_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run lint && npm run test',
+            'command': 'npm install --legacy-peer-deps && npm run lint && npm run test',
             'working_directory': str(nextjs_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nextjs_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -106,7 +106,7 @@ def test_nextjs_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_nuxt_template.py
+++ b/test/test_nuxt_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nuxt_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(nuxt_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(nuxt_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n       exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -98,7 +98,7 @@ def test_nuxt_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_qwik_template.py
+++ b/test/test_qwik_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(qwik_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(qwik_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(qwik_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -113,7 +113,7 @@ def test_qwik_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_remix_template.py
+++ b/test/test_remix_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(remix_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(remix_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(remix_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -104,7 +104,7 @@ def test_remix_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_remotion_template.py
+++ b/test/test_remotion_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(remotion_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(remotion_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(remotion_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -98,7 +98,7 @@ def test_remotion_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_slidev_template.py
+++ b/test/test_slidev_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(slidev_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(slidev_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(slidev_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx prettier --write "**/*.{js,ts,md,vue}"\nPRETTIER_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $PRETTIER_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -111,7 +111,7 @@ def test_slidev_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_svelte_template.py
+++ b/test/test_svelte_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(svelte_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run check && npm run test',
+            'command': 'npm install --legacy-peer-deps && npm run check && npm run test',
             'working_directory': str(svelte_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(svelte_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -101,7 +101,7 @@ def test_svelte_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 def test_project_initialization(template_dir, project_config):
     """Test basic project initialization."""

--- a/test/test_typescript_template.py
+++ b/test/test_typescript_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(typescript_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(typescript_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(typescript_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm run build\nEXIT_CODE=$?\nif [ $EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -99,7 +99,7 @@ def test_typescript_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 

--- a/test/test_vite_template.py
+++ b/test/test_vite_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(vite_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run build',
+            'command': 'npm install --legacy-peer-deps && npm run build',
             'working_directory': str(vite_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(vite_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || [ $BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -102,7 +102,7 @@ def test_vite_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):

--- a/test/test_vue_template.py
+++ b/test/test_vue_template.py
@@ -27,15 +27,15 @@ def template_dir(temp_dir):
     # Create mock config.yml
     config = {
         'configure_environment': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(vue_path)
         },
         'build_cmd': {
-            'command': 'npm install && npm run type-check && npm run test:unit -- --run',
+            'command': 'npm install --legacy-peer-deps && npm run type-check && npm run test:unit -- --run',
             'working_directory': str(vue_path)
         },
         'install_dependencies': {
-            'command': 'npm install',
+            'command': 'npm install --legacy-peer-deps',
             'working_directory': str(vue_path)
         },
         'env': {
@@ -58,7 +58,7 @@ def template_dir(temp_dir):
             'script_content': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpx eslint "$@"\nESLINT_EXIT_CODE=$?\nnpm run build\nBUILD_EXIT_CODE=$?\nif [ $ESLINT_EXIT_CODE -ne 0 ] || \n$BUILD_EXIT_CODE -ne 0 ]; then\n\t   exit 1\nfi'
         },
         'post_processing': {
-            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install'
+            'script': '#!/bin/bash\ncd {KAVIA_PROJECT_DIRECTORY}\nnpm install --legacy-peer-deps'
         }
     }
 
@@ -98,7 +98,7 @@ def test_vue_init_info(template_dir, project_config):
 
     # Check that init_info has all required components
     assert isinstance(init_info, TemplateInitInfo)
-    assert init_info.configure_environment.command == 'npm install'
+    assert init_info.configure_environment.command == 'npm install --legacy-peer-deps'
 
 
 def test_project_initialization(template_dir, project_config):


### PR DESCRIPTION
# Description
This should avoid install breaks with newer dependencies versions.